### PR TITLE
Bugfix autoloads

### DIFF
--- a/shanty-themes-dark-theme.el
+++ b/shanty-themes-dark-theme.el
@@ -81,7 +81,6 @@ a screen full of pleasant colors on a dark background.")
 The theme has to be reloaded after changing anything in the faces group."
   :group 'faces)
 
-;;;###autoload
 (when load-file-name
   (load-file (concat (file-name-directory load-file-name) "shanty-themes.el")))
 
@@ -90,4 +89,7 @@ The theme has to be reloaded after changing anything in the faces group."
 (provide-theme 'shanty-themes-dark)
 (provide 'shanty-themes-dark-theme)
 
+;; Local variables:
+;; package-lint-main-file: "shanty-themes.el"
+;; end:
 ;;; shanty-themes-dark-theme.el ends here

--- a/shanty-themes-dark-theme.el
+++ b/shanty-themes-dark-theme.el
@@ -81,13 +81,7 @@ a screen full of pleasant colors on a dark background.")
 The theme has to be reloaded after changing anything in the faces group."
   :group 'faces)
 
-(eval-and-compile
-  (unless (and (fboundp 'require-theme)
-               load-file-name
-               (equal (file-name-directory load-file-name)
-                      (expand-file-name "themes/" data-directory))
-               (require-theme 'shanty-themes t))
-    (require 'shanty-themes)))
+(require 'shanty-themes)
 
 (shanty-themes--activate-theme 'shanty-themes-dark shanty-themes-colors)
 

--- a/shanty-themes-dark-theme.el
+++ b/shanty-themes-dark-theme.el
@@ -81,8 +81,13 @@ a screen full of pleasant colors on a dark background.")
 The theme has to be reloaded after changing anything in the faces group."
   :group 'faces)
 
-(when load-file-name
-  (load-file (concat (file-name-directory load-file-name) "shanty-themes.el")))
+(eval-and-compile
+  (unless (and (fboundp 'require-theme)
+               load-file-name
+               (equal (file-name-directory load-file-name)
+                      (expand-file-name "themes/" data-directory))
+               (require-theme 'shanty-themes t))
+    (require 'shanty-themes)))
 
 (shanty-themes--activate-theme 'shanty-themes-dark shanty-themes-colors)
 

--- a/shanty-themes-light-theme.el
+++ b/shanty-themes-light-theme.el
@@ -81,8 +81,13 @@ a screen full of pleasant colors on a light background.")
 The theme has to be reloaded after changing anything in the faces group."
   :group 'faces)
 
-(when load-file-name
-  (load-file (concat (file-name-directory load-file-name) "shanty-themes.el")))
+(eval-and-compile
+  (unless (and (fboundp 'require-theme)
+               load-file-name
+               (equal (file-name-directory load-file-name)
+                      (expand-file-name "themes/" data-directory))
+               (require-theme 'shanty-themes t))
+    (require 'shanty-themes)))
 
 (shanty-themes--activate-theme 'shanty-themes-light shanty-themes-colors)
 

--- a/shanty-themes-light-theme.el
+++ b/shanty-themes-light-theme.el
@@ -81,7 +81,6 @@ a screen full of pleasant colors on a light background.")
 The theme has to be reloaded after changing anything in the faces group."
   :group 'faces)
 
-;;;###autoload
 (when load-file-name
   (load-file (concat (file-name-directory load-file-name) "shanty-themes.el")))
 
@@ -90,4 +89,7 @@ The theme has to be reloaded after changing anything in the faces group."
 (provide-theme 'shanty-themes-light)
 (provide 'shanty-themes-light-theme)
 
+;; Local variables:
+;; package-lint-main-file: "shanty-themes.el"
+;; end:
 ;;; shanty-themes-light-theme.el ends here

--- a/shanty-themes-light-theme.el
+++ b/shanty-themes-light-theme.el
@@ -81,13 +81,7 @@ a screen full of pleasant colors on a light background.")
 The theme has to be reloaded after changing anything in the faces group."
   :group 'faces)
 
-(eval-and-compile
-  (unless (and (fboundp 'require-theme)
-               load-file-name
-               (equal (file-name-directory load-file-name)
-                      (expand-file-name "themes/" data-directory))
-               (require-theme 'shanty-themes t))
-    (require 'shanty-themes)))
+(require 'shanty-themes)
 
 (shanty-themes--activate-theme 'shanty-themes-light shanty-themes-colors)
 


### PR DESCRIPTION
Removed the unnecessary autoloads from both theme files and replaced them with simple `(require 'shanty-themes)` statements.

Fixes: #3 